### PR TITLE
format OpenWrt Makefile and fix CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,8 @@ set(CMAKE_C_STANDARD 11)
 
 include_directories("/usr/local/include")
 
-add_executable(ua2f src/ua2f.c)
-add_executable(test test/test.c)
-add_executable(nf-queue ref/nf-queue.c)
-add_executable(clocktest test/clocktest.c)
-add_executable(nfct-event ref/nfct-event.c)
-add_executable(nfq test/nfq.c)
+add_executable(src/ua2f src/ua2f.c)
 
 target_link_libraries(ua2f mnl netfilter_queue ipset)
-target_link_libraries(nfct-event mnl netfilter_conntrack)
-target_link_libraries(nf-queue mnl netfilter_queue ipset)
-target_link_libraries(test mnl netfilter_queue ipset)
-target_link_libraries(clocktest mnl netfilter_queue)
-target_link_libraries(nfq mnl netfilter_queue)
+
+install(TARGETS src/ua2f RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_C_STANDARD 11)
 
 include_directories("/usr/local/include")
 
-add_executable(src/ua2f src/ua2f.c)
+add_executable(ua2f src/ua2f.c)
 
 target_link_libraries(ua2f mnl netfilter_queue ipset)
 
-install(TARGETS src/ua2f RUNTIME DESTINATION bin)
+install(TARGETS ua2f RUNTIME DESTINATION bin)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=UA2F
 PKG_VERSION:=3.7
+PKG_RELEASE:=11
 
-PKG_RELEASE:=10
-
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
-TARGET_LDFLAGS+=-lmnl -lnetfilter_queue -lipset
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILE:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -18,27 +15,23 @@ define Package/ua2f
   SUBMENU:=Routing and Redirection
   TITLE:=Change User-Agent to Fwords
   URL:=https://github.com/Zxilly/UA2F
-  DEPENDS:=+libmnl +libnetfilter-queue +iptables-mod-nfqueue +libipset
+  DEPENDS:=+iptables-mod-nfqueue +libipset +libnetfilter-conntrack +libnetfilter-queue
 endef
 
 define Package/ua2f/description
   Change User-agent to Fwords to prevent being checked by Dr.Com.
 endef
 
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-	cp ./src/* $(PKG_BUILD_DIR)
-	$(Build/Patch)
-endef
+EXTRA_LDFLAGS += -lmnl -lnetfilter_queue -lipset
 
 define Build/Compile
-	$(TARGET_CC) $(TARGET_CFLAGS) -o $(PKG_BUILD_DIR)/ua2f.o -c $(PKG_BUILD_DIR)/ua2f.c
-	$(TARGET_CC) $(TARGET_LDFLAGS) -o $(PKG_BUILD_DIR)/$1 $(PKG_BUILD_DIR)/ua2f.o
+	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_LDFLAGS) $(EXTRA_LDFLAGS) \
+		$(PKG_BUILD_DIR)/src/ua2f.c -o $(PKG_BUILD_DIR)/src/ua2f
 endef
 
 define Package/ua2f/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ua2f $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ua2f $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./init/ua2f $(1)/etc/init.d/ua2f
 endef

--- a/src/ua2f.c
+++ b/src/ua2f.c
@@ -14,7 +14,7 @@
 #include <strings.h>
 #include <unistd.h>
 #include <time.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <syslog.h>
 #include <signal.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
```git
Tianling Shen (3):
      style: format OpenWrt Makefile
      fix: remove obsolete targets in CMakeLists
      fix: remove compile warnings

 CMakeLists.txt | 12 ++----------
 Makefile       | 23 ++++++++---------------
 src/ua2f.c     |  2 +-
 3 files changed, 11 insertions(+), 26 deletions(-)
```