### PR TITLE
build(Makefile): correct build path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=UA2F
 PKG_VERSION:=3.7
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILE:=LICENSE
@@ -26,12 +26,12 @@ EXTRA_LDFLAGS += -lmnl -lnetfilter_queue -lipset
 
 define Build/Compile
 	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_LDFLAGS) $(EXTRA_LDFLAGS) \
-		$(PKG_BUILD_DIR)/src/ua2f.c -o $(PKG_BUILD_DIR)/src/ua2f
+		$(PKG_BUILD_DIR)/ua2f.c -o $(PKG_BUILD_DIR)/ua2f
 endef
 
 define Package/ua2f/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ua2f $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ua2f $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./init/ua2f $(1)/etc/init.d/ua2f
 endef


### PR DESCRIPTION
On OpenWrt, buildbot will copy all files from src to builddir root.

Fixes: 8b6739a16cf7be ("build: format OpenWrt Makefile and fix CMakeLists (#23)")

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>