### PR TITLE
fix pointer out of bounds

### DIFF
--- a/src/ua2f.c
+++ b/src/ua2f.c
@@ -290,12 +290,13 @@ static int queue_cb(const struct nlmsghdr *nlh, void *data) {
 
             if (uaoffset >= tcppklen) {
                 syslog(LOG_WARNING, "User-Agent position overflow, may caused by TCP Segment Reassembled.");
-                pktb_free(pktb);
+                nfq_send_verdict(ntohs(nfg->res_id), ntohl((uint32_t) ph->packet_id), pktb, mark, noUA, addcmd);
                 return MNL_CB_OK;
             }
 
             char *uaStartPointer = uapointer + 14;
-            for (int i = 0; i < tcppklen - uaoffset - 2; ++i) {
+            const unsigned int uaLengthBound = tcppklen - uaoffset;
+            for (unsigned int i = 0; i < uaLengthBound; ++i) {
                 if (*(uaStartPointer + i) == '\r') {
                     ualength = i;
                     break;


### PR DESCRIPTION
我在我的路由器发现了这样一条日志
`Mar 04 20:11:07 - UA2F[4191]: UA overflow, this is an unexpected error.`
可以使用类似于下面的命令来复现该问题
`echo -ne "\\r\\nUser-Agent: 1"|nc -v www.baidu.com 80`
上面的命令发送了一个数据包，其中tcppklen==15，uaoffset==14，由于他们都是unsigned int，因此tcppklen - uaoffset - 2并不是负数，而是一个很大的整数0xFFFFFFFF，因此*(uaStartPointer + i)可能会访问越界，不能确定for循环什么时候停止。
我还发现使用下面的命令发送的数据包不能通过
`echo -ne "\\r\\nUser-Agent: "|nc -v www.baidu.com 80`
日志显示
`User-Agent position overflow, may caused by TCP Segment Reassembled.`
我认为对于不能修改的UA，应当直接放行，而不是拦截。

此外，当ualength == 0，即UA分在两个数据包时，如下面的命令所示，
`echo -ne "\\r\\nUser-Agent: A_very_long_string"|nc -v www.baidu.com 80`
UA2F事实上没有修改UA，但却执行了UAcount++。我正在考虑添加一个变量来记录这种情况