### PR TITLE
add IPv6

### DIFF
--- a/src/ua2f.c
+++ b/src/ua2f.c
@@ -268,7 +268,7 @@ static int queue_cb(const struct nlmsghdr *nlh, void *data) {
     if (nfq_ip_set_transport_header(pktb, ippkhdl) < 0) {
 #else
     ippkhdl = nfq_ip6_get_hdr(pktb); //获取IPv6 header
-    if (nfq_ip6_set_transport_header(pktb, ippkhdl, IPPROTO_TCP) < 0) {
+    if (nfq_ip6_set_transport_header(pktb, ippkhdl, IPPROTO_TCP) != 1) {
 #endif
         syslog(LOG_ERR, "set transport header failed");
         pktb_free(pktb);


### PR DESCRIPTION
添加了处理IPv6的代码，用户可以定义SELECT_IPV6，选择编译IPv6的版本，否则默认编译IPv4的版本
由于我不太清楚如何将IPv6添加到ipset，所以我没有写出这些代码，不过这并不会导致不能编译运行
此外，NFQUEUE可以将数据包分配到多个队列实现负载均衡
`iptables -t mangle -A POSTROUTING -o pppoe-wan -p tcp -j NFQUEUE --queue-balance 10010:10013`
因此可以直接多进程而不是多线程，降低代码编写难度
我已经实现并实际运行了[多进程的代码](https://github.com/imguoliwei/UA2F-cpp)，我自己主要运行维护这个版本