### PR TITLE
fix procd service inactive

### DIFF
--- a/files/ua2f.init
+++ b/files/ua2f.init
@@ -68,7 +68,7 @@ start_service() {
 
 	local enabled
 	config_get_bool enabled "enabled" "enabled" "0"
-	[ "$enabled" -eq "1" ] || exit 1
+	[ "$enabled" -eq "1" ] || return 1
 
 	procd_open_instance "$NAME"
 	procd_set_param command "$PROG"


### PR DESCRIPTION
Exit directly will result procd service inactive and uci configuration changes are no longer monitored.