### PR TITLE
fix (ua2f.c):  Incorrect cycle conditions

### DIFF
--- a/src/ua2f.c
+++ b/src/ua2f.c
@@ -61,7 +61,7 @@ int main(const int argc, char *argv[]) {
         case IO_NOTREADY:
             continue;
         case IO_READY:
-            while (!should_exit) {
+            while (1) {
                 struct nf_packet packet[1];
                 switch (nfqueue_next(buf, packet)) {
                 case IO_ERROR:
@@ -69,7 +69,7 @@ int main(const int argc, char *argv[]) {
                     break;
                 case IO_READY:
                     handle_packet(queue, packet);
-                    break;
+                    continue;
                 case IO_NOTREADY:
                     // we've read every packet in the buffer
                     break;
@@ -80,7 +80,7 @@ int main(const int argc, char *argv[]) {
                     break;
                 }
             }
-            break;
+            continue;
         default:
             // we should never reach this point
             syslog(LOG_ERR, "Unknown return value [%s:%d]", __FILE__, __LINE__);


### PR DESCRIPTION
- 首先内循环中，`handle_packet`处理完毕后应该再立即检测是否是IO_READY，确保队列中每个包都被处理。由于每次`should_exit`设置后都有`break`，直接条件为`1`可以减少判断次数 ~~(虽然性能上可能几乎没有提升)~~。 
- 其次是外循环中，那个`IO_READY`中的 `break`会导致处理完一次队列后程序就自动退出