### PR TITLE
fix: compilation failed

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -14,7 +14,7 @@ pthread_rwlock_t cacheLock;
 struct cache *not_http_dst_cache = NULL;
 static int check_interval;
 
-_Noreturn static void* check_cache(void*) {
+_Noreturn static void* check_cache(void* arg) {
     while (true) {
         pthread_rwlock_wrlock(&cacheLock);
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -14,7 +14,7 @@ pthread_rwlock_t cacheLock;
 struct cache *not_http_dst_cache = NULL;
 static int check_interval;
 
-_Noreturn static void* check_cache(void* arg) {
+_Noreturn static void* check_cache(void* arg __attribute__((unused))) {
     while (true) {
         pthread_rwlock_wrlock(&cacheLock);
 


### PR DESCRIPTION
在ubuntu22.04下，lede编译错误：

```bash
ninja: Entering directory /home/sivon/lede/package/Sivon/UA2F/openwrt/../build'
[1/5] Building C object CMakeFiles/ua2f.dir/src/cache.c.o
FAILED: CMakeFiles/ua2f.dir/src/cache.c.o
/home/sivon/lede/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/bin/mipsel-openwrt-linux-musl-gcc -DUA2F_ENABLE_UCI=1 -DUA2F_GIT_BRANCH=\"\" -DUA2F_GIT_COMMIT=\"90c9d9f5edce00a6d79847f5249eb1fdf68de929\" -DUA2F_GIT_TAG=\"v4.8.2\" -DUA2F_USE_CUSTOM_UA=1 -DUA2F_VERSION=\"4.8.2\" -I/home/sivon/lede/package/Sivon/UA2F/build -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -msoft-float -fmacro-prefix-map=/home/sivon/lede/package/Sivon/UA2F/openwrt/..=.. -mips16 -minterlink-mips16 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -ffunction-sections -fdata-sections -DNDEBUG -std=gnu17 -MD -MT CMakeFiles/ua2f.dir/src/cache.c.o -MF CMakeFiles/ua2f.dir/src/cache.c.o.d -o CMakeFiles/ua2f.dir/src/cache.c.o -c /home/sivon/lede/package/Sivon/UA2F/src/cache.c
/home/sivon/lede/package/Sivon/UA2F/src/cache.c: In function 'check_cache':
/home/sivon/lede/package/Sivon/UA2F/src/cache.c:17:36: error: parameter name omitted
 _Noreturn static void* check_cache(void*) {
                                    ^~~~~
ninja: build stopped: subcommand failed.
```