### PR TITLE
test(openwrt): expand coverage and validate router flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libnetfilter-queue-dev libmnl-dev libnetfilter-conntrack-dev lcov libjson-c-dev lcov libpcap-dev
+          sudo apt-get install -y cmake libnetfilter-queue-dev libmnl-dev libnetfilter-conntrack-dev lcov libjson-c-dev libpcap-dev
 
       - name: Build and install libubox
         working-directory: /tmp
@@ -51,20 +51,21 @@ jobs:
           cmake .. -DBUILD_LUA=OFF
           make
           sudo make install
+          sudo ldconfig
 
       - name: Generate pcap test data
         run: python3 test/gen_pcap.py
 
       - name: Run unit tests
         run: |
-          cmake -S . -B build -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF
+          cmake -S . -B build -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=ON -DUA2F_ENABLE_COVERAGE=OFF
           cmake --build build
           ./build/ua2f_test
           ./build/ua2f_handler_test
 
       - name: Generate unit test coverage
         run: |
-          cmake -S . -B build-coverage -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF
+          cmake -S . -B build-coverage -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=ON -DUA2F_ENABLE_COVERAGE=ON
           cmake --build build-coverage
           cd build-coverage
           make coverage-lcov
@@ -75,6 +76,8 @@ jobs:
           files: build-coverage/coverage.info
           flags: unittests
           fail_ci_if_error: true
+          disable_search: true
+          plugins: noop
           verbose: true
           use_oidc: true
 
@@ -98,7 +101,7 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          cmake -S . -B build -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_BACKTRACE=OFF
+          cmake -S . -B build -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_BACKTRACE=OFF -DUA2F_ENABLE_COVERAGE=OFF
           cmake --build build
           ./build/ua2f_test
           ./build/ua2f_handler_test
@@ -116,21 +119,21 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libnetfilter-queue-dev libmnl-dev libnetfilter-conntrack-dev lcov lcov libpcap-dev
+          sudo apt-get install -y cmake libnetfilter-queue-dev libmnl-dev libnetfilter-conntrack-dev lcov libpcap-dev
 
       - name: Generate pcap test data
         run: python3 test/gen_pcap.py
 
       - name: Run unit tests
         run: |
-          cmake -S . -B build -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF
+          cmake -S . -B build -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_COVERAGE=OFF
           cmake --build build
           ./build/ua2f_test
           ./build/ua2f_handler_test
 
       - name: Generate unit test coverage (standalone)
         run: |
-          cmake -S . -B build-coverage -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF
+          cmake -S . -B build-coverage -DUA2F_BUILD_TESTS=ON -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_COVERAGE=ON
           cmake --build build-coverage
           cd build-coverage
           make coverage-lcov
@@ -141,6 +144,8 @@ jobs:
           files: build-coverage/coverage.info
           flags: unittests-standalone
           fail_ci_if_error: true
+          disable_search: true
+          plugins: noop
           verbose: true
           use_oidc: true
 
@@ -151,7 +156,11 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        cache: [ "-DUA2F_NO_CACHE=ON", "-DUA2F_NO_CACHE=OFF" ]
+        include:
+          - name: cache
+            cache: -DUA2F_NO_CACHE=OFF
+          - name: no-cache
+            cache: -DUA2F_NO_CACHE=ON
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -159,7 +168,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libnetfilter-queue-dev libmnl-dev libnetfilter-conntrack-dev lcov
+          sudo apt-get install -y cmake iproute2 iptables nftables kmod libnetfilter-queue-dev libmnl-dev libnetfilter-conntrack-dev lcov
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -188,15 +197,16 @@ jobs:
 
       - name: Run integration tests
         run: |
-          cmake -S . -B build -DUA2F_BUILD_TESTS=OFF -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_ASAN=ON ${{ matrix.cache }}
+          cmake -S . -B build -DUA2F_BUILD_TESTS=OFF -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_BACKTRACE=OFF -DUA2F_ENABLE_ASAN=ON -DUA2F_ENABLE_COVERAGE=OFF ${{ matrix.cache }}
           cmake --build build
           sudo ./build/ua2f --version
           sudo -E $(which python3) scripts/test.py ./build/ua2f
+          sudo -E $(which python3) scripts/test_netns.py ./build/ua2f
 
       - name: Generate integration test coverage
         run: |
           # Build with coverage enabled for integration testing
-          cmake -S . -B build-coverage -DUA2F_BUILD_TESTS=OFF -DUA2F_ENABLE_UCI=OFF ${{ matrix.cache }}
+          cmake -S . -B build-coverage -DUA2F_BUILD_TESTS=OFF -DUA2F_ENABLE_UCI=OFF -DUA2F_ENABLE_BACKTRACE=OFF -DUA2F_ENABLE_COVERAGE=ON ${{ matrix.cache }}
           cmake --build build-coverage
           cd build-coverage
           
@@ -206,6 +216,7 @@ jobs:
           # Run integration tests with coverage-enabled binary
           sudo ./ua2f --version
           sudo -E $(which python3) ../scripts/test.py ./ua2f
+          sudo -E $(which python3) ../scripts/test_netns.py ./ua2f
           
           # Process coverage data with lcov
           make coverage-integration-process
@@ -230,15 +241,17 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: build-coverage/coverage-integration.info
-          flags: integration
+          flags: integration-${{ matrix.name }}
           fail_ci_if_error: true
+          disable_search: true
+          plugins: noop
           use_oidc: true
           verbose: true
 
       - name: Upload log
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: syslog-cache-${{ matrix.cache }}
+          name: syslog-${{ matrix.name }}
           path: /var/log/syslog
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,8 @@ jobs:
           - mipsel_24kc
           - x86_64
         version:
-          - 23.05.5
-          - 24.10.0
+          - 24.10.8
+          - 25.12.5
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -292,27 +292,33 @@ jobs:
           PACKAGES: openwrt
           V: sc
 
-      - name: Move created packages to project dir
+      - name: Collect created packages
+        shell: bash
         run: |
-          mkdir -p tmp
-          cp bin/packages/${{ matrix.arch }}/packages_ci/*.ipk tmp/ || true
-          for f in tmp/*.ipk; do mv "$f" "${f/.ipk/-${{ matrix.version }}.ipk}" 2>/dev/null || true; done
-          mv tmp/*.ipk . 2>/dev/null || true
-          rm -rf tmp
+          mkdir -p artifacts
+          while IFS= read -r -d '' package; do
+            extension="${package##*.}"
+            stem="$(basename "$package" ".$extension")"
+            cp "$package" "artifacts/${stem}-${{ matrix.version }}.${extension}"
+          done < <(
+            find "bin/packages/${{ matrix.arch }}/packages_ci" -maxdepth 1 -type f \
+              \( -name '*.ipk' -o -name '*.apk' \) -print0
+          )
+          test -n "$(find artifacts -type f -print -quit)"
           
       - name: Store packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: "!startsWith(github.ref, 'refs/tags/v')"
         with:
           name: ${{ matrix.arch }}-${{ github.sha }}-${{ matrix.version }}-packages
-          path: "*.ipk"
+          path: artifacts/*
 
       - name: Upload packages
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         if: "startsWith(github.ref, 'refs/tags/v')"
         with:
           repo_token: ${{ github.token }}
-          file: "*.ipk"
+          file: "artifacts/*"
           tag: ${{ github.ref }}
           file_glob: true
 

--- a/.github/workflows/openwrt-qemu.yml
+++ b/.github/workflows/openwrt-qemu.yml
@@ -49,6 +49,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Read package version
+        shell: bash
+        run: |
+          version="$(sed -n 's/^PKG_VERSION:=//p' openwrt/Makefile)"
+          test -n "$version"
+          echo "UA2F_VERSION=$version" >> "$GITHUB_ENV"
+
       - name: Build x86_64 package
         uses: openwrt/gh-action-sdk@7fc2640243284ecc44f4a9c3f749a61746ee02cb # v11
         env:
@@ -63,7 +70,6 @@ jobs:
           package="$(find bin/packages -type f \( -iname '*ua2f*.ipk' -o -iname '*ua2f*.apk' \) -print -quit)"
           test -n "$package"
           echo "UA2F_PACKAGE=$package" >> "$GITHUB_ENV"
-          echo "UA2F_VERSION=$(sed -n 's/^PKG_VERSION:=//p' openwrt/Makefile)" >> "$GITHUB_ENV"
 
       - name: Install QEMU test dependencies
         run: |
@@ -77,7 +83,14 @@ jobs:
         run: |
           curl --fail --location --retry 5 "$IMAGE_URL" --output openwrt.img.gz
           echo "$IMAGE_SHA256  openwrt.img.gz" | sha256sum --check --strict
-          gzip --decompress openwrt.img.gz
+          gzip_status=0
+          gzip --decompress --stdout openwrt.img.gz > openwrt.img || gzip_status=$?
+          # Combined images contain signed trailing data, for which gzip returns 2.
+          case "$gzip_status" in
+            0|2) ;;
+            *) exit "$gzip_status" ;;
+          esac
+          test -s openwrt.img
 
       - name: Exercise the package in OpenWrt
         run: |

--- a/.github/workflows/openwrt-qemu.yml
+++ b/.github/workflows/openwrt-qemu.yml
@@ -49,12 +49,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Read package version
+      - name: Preserve QEMU test inputs
         shell: bash
         run: |
           version="$(sed -n 's/^PKG_VERSION:=//p' openwrt/Makefile)"
           test -n "$version"
           echo "UA2F_VERSION=$version" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ua2f-qemu"
+          cp scripts/http_test_endpoint.py scripts/test_openwrt_qemu.py \
+            "$RUNNER_TEMP/ua2f-qemu/"
 
       - name: Build x86_64 package
         uses: openwrt/gh-action-sdk@7fc2640243284ecc44f4a9c3f749a61746ee02cb # v11
@@ -94,7 +97,7 @@ jobs:
 
       - name: Exercise the package in OpenWrt
         run: |
-          sudo -E python3 scripts/test_openwrt_qemu.py \
+          sudo -E python3 "$RUNNER_TEMP/ua2f-qemu/test_openwrt_qemu.py" \
             --image openwrt.img \
             --package "$UA2F_PACKAGE" \
             --expected-version "$UA2F_VERSION" \

--- a/.github/workflows/openwrt-qemu.yml
+++ b/.github/workflows/openwrt-qemu.yml
@@ -1,0 +1,96 @@
+name: OpenWrt QEMU integration
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/openwrt-qemu.yml'
+      - 'CMakeLists.txt'
+      - 'openwrt/**'
+      - 'scripts/http_test_endpoint.py'
+      - 'scripts/test_openwrt_qemu.py'
+      - 'src/**'
+  pull_request:
+    paths:
+      - '.github/workflows/openwrt-qemu.yml'
+      - 'CMakeLists.txt'
+      - 'openwrt/**'
+      - 'scripts/http_test_endpoint.py'
+      - 'scripts/test_openwrt_qemu.py'
+      - 'src/**'
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openwrt-qemu-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qemu:
+    name: OpenWrt ${{ matrix.version }} x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: 23.05.5
+            image_url: https://downloads.openwrt.org/releases/23.05.5/targets/x86/64/openwrt-23.05.5-x86-64-generic-ext4-combined.img.gz
+            image_sha256: f5c77659a33bd43cba105cf2f75e56d054fa9e0b9a73dc9f2a5bcb0e126ff7d5
+          - version: 24.10.0
+            image_url: https://downloads.openwrt.org/releases/24.10.0/targets/x86/64/openwrt-24.10.0-x86-64-generic-ext4-combined.img.gz
+            image_sha256: a873d9f2e6e667d03dd06f75ed1f1b580beb7ce4337d5a44b60911a266965fb5
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build x86_64 package
+        uses: openwrt/gh-action-sdk@7fc2640243284ecc44f4a9c3f749a61746ee02cb # v11
+        env:
+          ARCH: x86_64-${{ matrix.version }}
+          FEEDNAME: packages_ci
+          PACKAGES: openwrt
+          V: sc
+
+      - name: Locate package
+        shell: bash
+        run: |
+          package="$(find bin/packages -type f -iname '*ua2f*.ipk' -print -quit)"
+          test -n "$package"
+          echo "UA2F_IPK=$package" >> "$GITHUB_ENV"
+          echo "UA2F_VERSION=$(sed -n 's/^PKG_VERSION:=//p' openwrt/Makefile)" >> "$GITHUB_ENV"
+
+      - name: Install QEMU test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iproute2 qemu-system-x86 qemu-utils python3-pexpect
+
+      - name: Download verified OpenWrt image
+        env:
+          IMAGE_URL: ${{ matrix.image_url }}
+          IMAGE_SHA256: ${{ matrix.image_sha256 }}
+        run: |
+          curl --fail --location --retry 5 "$IMAGE_URL" --output openwrt.img.gz
+          echo "$IMAGE_SHA256  openwrt.img.gz" | sha256sum --check --strict
+          gzip --decompress openwrt.img.gz
+
+      - name: Exercise the package in OpenWrt
+        run: |
+          sudo -E python3 scripts/test_openwrt_qemu.py \
+            --image openwrt.img \
+            --package "$UA2F_IPK" \
+            --expected-version "$UA2F_VERSION" \
+            --log "openwrt-${{ matrix.version }}-qemu.log"
+
+      - name: Upload QEMU console log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openwrt-${{ matrix.version }}-qemu-log
+          path: openwrt-${{ matrix.version }}-qemu.log
+          if-no-files-found: warn

--- a/.github/workflows/openwrt-qemu.yml
+++ b/.github/workflows/openwrt-qemu.yml
@@ -39,12 +39,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: 23.05.5
-            image_url: https://downloads.openwrt.org/releases/23.05.5/targets/x86/64/openwrt-23.05.5-x86-64-generic-ext4-combined.img.gz
-            image_sha256: f5c77659a33bd43cba105cf2f75e56d054fa9e0b9a73dc9f2a5bcb0e126ff7d5
-          - version: 24.10.0
-            image_url: https://downloads.openwrt.org/releases/24.10.0/targets/x86/64/openwrt-24.10.0-x86-64-generic-ext4-combined.img.gz
-            image_sha256: a873d9f2e6e667d03dd06f75ed1f1b580beb7ce4337d5a44b60911a266965fb5
+          - version: 24.10.8
+            image_url: https://downloads.openwrt.org/releases/24.10.8/targets/x86/64/openwrt-24.10.8-x86-64-generic-ext4-combined.img.gz
+            image_sha256: 23872c64fdb66d0765e0d17f71453a66e7a91e9ecb10606d5f738e6d166e14ae
+          - version: 25.12.5
+            image_url: https://downloads.openwrt.org/releases/25.12.5/targets/x86/64/openwrt-25.12.5-x86-64-generic-ext4-combined.img.gz
+            image_sha256: 23e2538e8ab0eb52dfed1c65d608ecdb71ffd432dd54885da138ae67cd9e4461
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,9 +60,9 @@ jobs:
       - name: Locate package
         shell: bash
         run: |
-          package="$(find bin/packages -type f -iname '*ua2f*.ipk' -print -quit)"
+          package="$(find bin/packages -type f \( -iname '*ua2f*.ipk' -o -iname '*ua2f*.apk' \) -print -quit)"
           test -n "$package"
-          echo "UA2F_IPK=$package" >> "$GITHUB_ENV"
+          echo "UA2F_PACKAGE=$package" >> "$GITHUB_ENV"
           echo "UA2F_VERSION=$(sed -n 's/^PKG_VERSION:=//p' openwrt/Makefile)" >> "$GITHUB_ENV"
 
       - name: Install QEMU test dependencies
@@ -83,7 +83,7 @@ jobs:
         run: |
           sudo -E python3 scripts/test_openwrt_qemu.py \
             --image openwrt.img \
-            --package "$UA2F_IPK" \
+            --package "$UA2F_PACKAGE" \
             --expected-version "$UA2F_VERSION" \
             --log "openwrt-${{ matrix.version }}-qemu.log"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,7 @@ set(CMAKE_C_STANDARD 17)
 cmake_policy(SET CMP0135 NEW)
 
 OPTION(UA2F_BUILD_TESTS "Build tests" OFF)
-
-if(DEFINED ENV{CI})
-    # In CI, always enable coverage for all builds
-    set(UA2F_ENABLE_COVERAGE ON CACHE BOOL "Enable code coverage (auto-enabled in CI)" FORCE)
-    message(STATUS "Auto-enabling coverage in CI environment")
-else()
-    OPTION(UA2F_ENABLE_COVERAGE "Enable code coverage" OFF)
-endif()
+OPTION(UA2F_ENABLE_COVERAGE "Enable code coverage" OFF)
 
 OPTION(UA2F_ENABLE_UCI "Enable UCI support" ON)
 OPTION(UA2F_NO_CACHE "Disable cache" OFF)
@@ -295,6 +288,7 @@ if (UA2F_BUILD_TESTS)
     target_include_directories(ua2f_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     target_include_directories(ua2f_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/third/llhttp)
     if (UA2F_ENABLE_UCI)
+        target_sources(ua2f_test PRIVATE test/config_test.cc)
         target_sources(ua2f_test PRIVATE src/config.c)
         target_link_libraries(ua2f_test uci)
     endif ()

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,13 +3,13 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 30%
-        informational: true
+        threshold: 1%
+        informational: false
     patch:
       default:
-        target: auto
-        threshold: 30%
-        informational: true
+        target: 80%
+        threshold: 0%
+        informational: false
 
 ignore:
   - "src/third/"
@@ -22,18 +22,23 @@ flags:
   unittests-standalone:
     paths:
       - src/
-  integration:
+  integration-cache:
+    paths:
+      - src/
+  integration-no-cache:
     paths:
       - src/
 
 flag_management:
   default_rules:
-    carryforward: true
+    carryforward: false
     statuses:
       - type: project
         target: auto
+        threshold: 1%
       - type: patch
-        target: auto
+        target: 80%
+        threshold: 0%
 
 comment:
   layout: "reach,diff,flags,files,footer"

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=UA2F
-PKG_VERSION:=4.10.2
+PKG_VERSION:=5.2.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-only

--- a/openwrt/files/ua2f.init
+++ b/openwrt/files/ua2f.init
@@ -272,8 +272,8 @@ setup_firewall_tproxy() {
 						tcp dport $listen_port counter return comment "!ua2f: bypass proxy listener";
 						$([ "$handle_tls" -eq "1" ] || echo 'tcp dport 443 counter return comment "!ua2f: bypass HTTPS";')
 						meta mark $PROXY_MARK counter return comment "!ua2f: bypass ua2f outbound";
-						meta nfproto ipv4 meta mark set $TPROXY_MARK tproxy ip to 127.0.0.1:$listen_port counter accept;
-						meta nfproto ipv6 meta mark set $TPROXY_MARK tproxy ip6 to [::1]:$listen_port counter accept;
+						meta nfproto ipv4 meta l4proto tcp meta mark set $TPROXY_MARK tproxy ip to 127.0.0.1:$listen_port counter accept;
+						meta nfproto ipv6 meta l4proto tcp meta mark set $TPROXY_MARK tproxy ip6 to [::1]:$listen_port counter accept;
 					}
 				}
 			EOF

--- a/scripts/http_test_endpoint.py
+++ b/scripts/http_test_endpoint.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Small dependency-free HTTP endpoint and keep-alive probe for integration tests."""
+
+import argparse
+import http.client
+import http.server
+import json
+import signal
+import socket
+import threading
+import urllib.parse
+
+
+class EchoHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _handle(self, include_body=True):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        request_body = self.rfile.read(content_length).decode("utf-8", errors="replace")
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(self.path).query)
+        padding_bytes = min(int(query.get("padding", ["0"])[0]), 1024 * 1024)
+        payload = json.dumps(
+            {
+                "user_agent": self.headers.get("User-Agent"),
+                "method": self.command,
+                "body": request_body,
+                "path": self.path,
+                "padding": "x" * padding_bytes,
+            },
+            separators=(",", ":"),
+        ).encode()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if include_body:
+            self.wfile.write(payload)
+
+    do_GET = _handle
+    do_POST = _handle
+    do_PUT = _handle
+    do_DELETE = _handle
+    do_PATCH = _handle
+    do_OPTIONS = _handle
+
+    def do_HEAD(self):
+        self._handle(include_body=False)
+
+    def log_message(self, format_string, *args):
+        return
+
+
+class IPv6ThreadingHTTPServer(http.server.ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+
+    def server_bind(self):
+        self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        super().server_bind()
+
+
+def serve(args):
+    servers = []
+    threads = []
+    for port in args.port:
+        servers.append(http.server.ThreadingHTTPServer((args.bind_ipv4, port), EchoHandler))
+        if args.ipv6:
+            servers.append(IPv6ThreadingHTTPServer((args.bind_ipv6, port), EchoHandler))
+
+    stopped = threading.Event()
+
+    def stop(_signum, _frame):
+        stopped.set()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    for server in servers:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        threads.append(thread)
+
+    stopped.wait()
+    for server in servers:
+        server.shutdown()
+        server.server_close()
+    for thread in threads:
+        thread.join(timeout=5)
+
+
+def probe(args):
+    connection = http.client.HTTPConnection(args.host, args.port, timeout=args.timeout)
+    responses = []
+    try:
+        for _ in range(args.requests):
+            headers = {}
+            if not args.omit_user_agent:
+                headers["User-Agent"] = args.user_agent
+            body = args.body.encode() if args.body is not None else None
+            connection.request(args.method, args.path, body=body, headers=headers)
+            response = connection.getresponse()
+            response_body = response.read()
+            if response.status != 200:
+                raise RuntimeError(f"HTTP {response.status}: {response_body[:200]!r}")
+            responses.append(json.loads(response_body))
+    finally:
+        connection.close()
+    print(json.dumps(responses, separators=(",", ":")))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    server_parser = subparsers.add_parser("serve")
+    server_parser.add_argument("--bind-ipv4", default="0.0.0.0")
+    server_parser.add_argument("--bind-ipv6", default="::")
+    server_parser.add_argument("--ipv6", action="store_true")
+    server_parser.add_argument("--port", type=int, action="append", required=True)
+    server_parser.set_defaults(func=serve)
+
+    probe_parser = subparsers.add_parser("probe")
+    probe_parser.add_argument("--host", required=True)
+    probe_parser.add_argument("--port", type=int, default=80)
+    probe_parser.add_argument("--path", default="/")
+    probe_parser.add_argument("--method", default="GET")
+    probe_parser.add_argument("--body")
+    probe_parser.add_argument("--user-agent", default="UA2F-Integration/1.0")
+    probe_parser.add_argument("--omit-user-agent", action="store_true")
+    probe_parser.add_argument("--requests", type=int, default=1)
+    probe_parser.add_argument("--timeout", type=float, default=10)
+    probe_parser.set_defaults(func=probe)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    arguments = parse_args()
+    arguments.func(arguments)

--- a/scripts/test_netns.py
+++ b/scripts/test_netns.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Exercise UA2F as a routed NFQUEUE/REDIRECT/TPROXY middlebox."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+PROXY_MARK = "0xc9"
+TPROXY_MARK = "0x1c9"
+TPROXY_TABLE = "457"
+LISTEN_PORT = "10010"
+TEST_USER_AGENT = "UA2F-Netns/1.0"
+POST_BODY = "User-Agent: this text is an HTTP body and must remain unchanged"
+
+
+class RoutedIntegrationTest:
+    def __init__(self, binary, modes, ipv6=True):
+        self.binary = Path(binary).resolve()
+        self.modes = modes
+        self.ipv6 = ipv6
+        suffix = f"{os.getpid():x}"[-5:]
+        self.client_ns = f"ua2f-client-{suffix}"
+        self.router_ns = f"ua2f-router-{suffix}"
+        self.origin_ns = f"ua2f-origin-{suffix}"
+        self.client_if = f"u2c{suffix}"
+        self.router_lan_if = f"u2l{suffix}"
+        self.origin_if = f"u2o{suffix}"
+        self.router_wan_if = f"u2w{suffix}"
+        self.origin_process = None
+        self.ua2f_process = None
+        self.ua2f_log = tempfile.NamedTemporaryFile(prefix="ua2f-netns-", suffix=".log", delete=False)
+        self.helper = Path(__file__).with_name("http_test_endpoint.py").resolve()
+
+    @staticmethod
+    def _run(command, check=True, capture=False):
+        result = subprocess.run(
+            [str(part) for part in command],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stderr=subprocess.STDOUT if capture else subprocess.DEVNULL,
+        )
+        if check and result.returncode != 0:
+            output = result.stdout.strip() if result.stdout else ""
+            raise RuntimeError(f"command failed ({result.returncode}): {' '.join(map(str, command))}\n{output}")
+        return result
+
+    def _ns_run(self, namespace, command, check=True, capture=False):
+        return self._run(["ip", "netns", "exec", namespace, *command], check=check, capture=capture)
+
+    def preflight(self):
+        if os.name != "posix" or os.geteuid() != 0:
+            raise RuntimeError("test_netns.py requires Linux root privileges")
+        if not self.binary.is_file():
+            raise RuntimeError(f"UA2F binary not found: {self.binary}")
+        for executable in ("ip", "iptables", "ip6tables"):
+            if shutil.which(executable) is None:
+                raise RuntimeError(f"required executable not found: {executable}")
+        for module in ("nfnetlink_queue", "xt_TPROXY", "nf_tproxy_ipv4", "nf_tproxy_ipv6"):
+            self._run(["modprobe", module], check=False)
+
+    def setup_network(self):
+        for namespace in (self.client_ns, self.router_ns, self.origin_ns):
+            self._run(["ip", "netns", "add", namespace])
+            self._run(["ip", "-n", namespace, "link", "set", "lo", "up"])
+
+        self._run(["ip", "link", "add", self.client_if, "type", "veth", "peer", "name", self.router_lan_if])
+        self._run(["ip", "link", "set", self.client_if, "netns", self.client_ns])
+        self._run(["ip", "link", "set", self.router_lan_if, "netns", self.router_ns])
+        self._run(["ip", "link", "add", self.origin_if, "type", "veth", "peer", "name", self.router_wan_if])
+        self._run(["ip", "link", "set", self.origin_if, "netns", self.origin_ns])
+        self._run(["ip", "link", "set", self.router_wan_if, "netns", self.router_ns])
+
+        addresses = (
+            (self.client_ns, self.client_if, "10.241.1.2/24"),
+            (self.router_ns, self.router_lan_if, "10.241.1.1/24"),
+            (self.origin_ns, self.origin_if, "10.241.2.2/24"),
+            (self.router_ns, self.router_wan_if, "10.241.2.1/24"),
+        )
+        for namespace, interface, address in addresses:
+            self._run(["ip", "-n", namespace, "addr", "add", address, "dev", interface])
+            self._run(["ip", "-n", namespace, "link", "set", interface, "up"])
+
+        self._run(["ip", "-n", self.client_ns, "route", "add", "default", "via", "10.241.1.1"])
+        self._run(["ip", "-n", self.origin_ns, "route", "add", "default", "via", "10.241.2.1"])
+
+        if self.ipv6:
+            ipv6_addresses = (
+                (self.client_ns, self.client_if, "fd42:241:1::2/64"),
+                (self.router_ns, self.router_lan_if, "fd42:241:1::1/64"),
+                (self.origin_ns, self.origin_if, "fd42:241:2::2/64"),
+                (self.router_ns, self.router_wan_if, "fd42:241:2::1/64"),
+            )
+            for namespace, interface, address in ipv6_addresses:
+                self._run(["ip", "-n", namespace, "-6", "addr", "add", address, "dev", interface, "nodad"])
+            self._run(["ip", "-n", self.client_ns, "-6", "route", "add", "default", "via", "fd42:241:1::1"])
+            self._run(["ip", "-n", self.origin_ns, "-6", "route", "add", "default", "via", "fd42:241:2::1"])
+
+        self._ns_run(self.router_ns, ["sysctl", "-qw", "net.ipv4.ip_forward=1"])
+        self._ns_run(self.router_ns, ["sysctl", "-qw", "net.ipv4.conf.all.rp_filter=0"])
+        self._ns_run(self.router_ns, ["sysctl", "-qw", "net.ipv4.conf.default.rp_filter=0"])
+        if self.ipv6:
+            self._ns_run(self.router_ns, ["sysctl", "-qw", "net.ipv6.conf.all.forwarding=1"])
+
+    def start_origin(self):
+        command = [
+            "ip",
+            "netns",
+            "exec",
+            self.origin_ns,
+            sys.executable,
+            str(self.helper),
+            "serve",
+            "--port",
+            "80",
+            "--port",
+            "443",
+        ]
+        if self.ipv6:
+            command.append("--ipv6")
+        self.origin_process = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                result = self.probe("10.241.2.2", user_agent="origin-ready")
+                if result[0]["user_agent"] == "origin-ready":
+                    return
+            except (RuntimeError, json.JSONDecodeError):
+                time.sleep(0.2)
+        raise RuntimeError("origin HTTP endpoint did not become ready")
+
+    def flush_firewall(self):
+        for command in ("iptables", "ip6tables"):
+            for table in ("mangle", "nat"):
+                self._ns_run(self.router_ns, [command, "-t", table, "-F"], check=False)
+                self._ns_run(self.router_ns, [command, "-t", table, "-X"], check=False)
+        self._ns_run(
+            self.router_ns,
+            ["ip", "rule", "del", "fwmark", TPROXY_MARK, "table", TPROXY_TABLE],
+            check=False,
+        )
+        self._ns_run(self.router_ns, ["ip", "route", "flush", "table", TPROXY_TABLE], check=False)
+        if self.ipv6:
+            self._ns_run(
+                self.router_ns,
+                ["ip", "-6", "rule", "del", "fwmark", TPROXY_MARK, "table", TPROXY_TABLE],
+                check=False,
+            )
+            self._ns_run(self.router_ns, ["ip", "-6", "route", "flush", "table", TPROXY_TABLE], check=False)
+
+    def setup_firewall(self, mode):
+        self.flush_firewall()
+        if mode == "NFQUEUE":
+            self._ns_run(
+                self.router_ns,
+                [
+                    "iptables", "-t", "mangle", "-A", "POSTROUTING", "-o", self.router_wan_if,
+                    "-p", "tcp", "--dport", "80", "-m", "conntrack", "--ctdir", "ORIGINAL",
+                    "-j", "NFQUEUE", "--queue-num", "10010",
+                ],
+            )
+            if self.ipv6:
+                self._ns_run(
+                    self.router_ns,
+                    [
+                        "ip6tables", "-t", "mangle", "-A", "POSTROUTING", "-o", self.router_wan_if,
+                        "-p", "tcp", "--dport", "80", "-m", "conntrack", "--ctdir", "ORIGINAL",
+                        "-j", "NFQUEUE", "--queue-num", "10010",
+                    ],
+                )
+            return
+
+        if mode == "REDIRECT":
+            self._ns_run(
+                self.router_ns,
+                [
+                    "iptables", "-t", "nat", "-A", "PREROUTING", "-i", self.router_lan_if,
+                    "-p", "tcp", "--dport", "80", "-m", "mark", "!", "--mark", PROXY_MARK,
+                    "-j", "REDIRECT", "--to-ports", LISTEN_PORT,
+                ],
+            )
+            if self.ipv6:
+                self._ns_run(
+                    self.router_ns,
+                    [
+                        "ip6tables", "-t", "nat", "-A", "PREROUTING", "-i", self.router_lan_if,
+                        "-p", "tcp", "--dport", "80", "-m", "mark", "!", "--mark", PROXY_MARK,
+                        "-j", "REDIRECT", "--to-ports", LISTEN_PORT,
+                    ],
+                )
+            return
+
+        if mode != "TPROXY":
+            raise RuntimeError(f"unsupported test mode: {mode}")
+
+        self._ns_run(self.router_ns, ["ip", "rule", "add", "fwmark", TPROXY_MARK, "table", TPROXY_TABLE])
+        self._ns_run(
+            self.router_ns,
+            ["ip", "route", "replace", "local", "0.0.0.0/0", "dev", "lo", "table", TPROXY_TABLE],
+        )
+        self._ns_run(
+            self.router_ns,
+            [
+                "iptables", "-t", "mangle", "-A", "PREROUTING", "-i", self.router_lan_if,
+                "-p", "tcp", "--dport", "80", "-m", "mark", "!", "--mark", PROXY_MARK,
+                "-j", "TPROXY", "--on-ip", "127.0.0.1", "--on-port", LISTEN_PORT,
+                "--tproxy-mark", f"{TPROXY_MARK}/0xffffffff",
+            ],
+        )
+        if self.ipv6:
+            self._ns_run(
+                self.router_ns,
+                ["ip", "-6", "rule", "add", "fwmark", TPROXY_MARK, "table", TPROXY_TABLE],
+            )
+            self._ns_run(
+                self.router_ns,
+                ["ip", "-6", "route", "replace", "local", "::/0", "dev", "lo", "table", TPROXY_TABLE],
+            )
+            self._ns_run(
+                self.router_ns,
+                [
+                    "ip6tables", "-t", "mangle", "-A", "PREROUTING", "-i", self.router_lan_if,
+                    "-p", "tcp", "--dport", "80", "-m", "mark", "!", "--mark", PROXY_MARK,
+                    "-j", "TPROXY", "--on-ip", "::1", "--on-port", LISTEN_PORT,
+                    "--tproxy-mark", f"{TPROXY_MARK}/0xffffffff",
+                ],
+            )
+
+    def start_ua2f(self, mode):
+        environment = ["env"]
+        if mode in ("REDIRECT", "TPROXY"):
+            environment.append("UA2F_PROXY_WORKERS=2")
+        command = [
+            "ip",
+            "netns",
+            "exec",
+            self.router_ns,
+            *environment,
+            str(self.binary),
+            "--mode",
+            mode,
+            "--listen-port",
+            LISTEN_PORT,
+        ]
+        self.ua2f_process = subprocess.Popen(command, stdout=self.ua2f_log, stderr=subprocess.STDOUT)
+        time.sleep(1)
+        if self.ua2f_process.poll() is not None:
+            raise RuntimeError(f"UA2F exited while starting {mode}\n{self.read_ua2f_log()}")
+
+    def stop_ua2f(self):
+        if self.ua2f_process is None:
+            return
+        if self.ua2f_process.poll() is None:
+            self.ua2f_process.send_signal(signal.SIGTERM)
+            try:
+                self.ua2f_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.ua2f_process.kill()
+                self.ua2f_process.wait(timeout=5)
+        if self.ua2f_process.returncode not in (0, -signal.SIGTERM):
+            raise RuntimeError(f"UA2F exited with {self.ua2f_process.returncode}\n{self.read_ua2f_log()}")
+        self.ua2f_process = None
+
+    def probe(self, host, port=80, user_agent=TEST_USER_AGENT, requests=1, method="GET", body=None, path="/"):
+        command = [
+            sys.executable,
+            str(self.helper),
+            "probe",
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--requests",
+            str(requests),
+            "--method",
+            method,
+            "--path",
+            path,
+        ]
+        if user_agent is None:
+            command.append("--omit-user-agent")
+        else:
+            command.extend(["--user-agent", user_agent])
+        if body is not None:
+            command.extend(["--body", body])
+        result = self._ns_run(self.client_ns, command, capture=True)
+        return json.loads(result.stdout)
+
+    @staticmethod
+    def assert_rewritten(responses, expected_user_agent, label):
+        for index, response in enumerate(responses):
+            actual = response["user_agent"]
+            if actual != expected_user_agent:
+                raise AssertionError(f"{label} response {index}: expected UA {expected_user_agent!r}, got {actual!r}")
+
+    def exercise_mode(self, mode):
+        print(f"[netns] testing {mode}", flush=True)
+        self.setup_firewall(mode)
+        self.start_ua2f(mode)
+        expected = "F" * len(TEST_USER_AGENT)
+        try:
+            responses = self.probe("10.241.2.2", requests=3, path="/keepalive?padding=65536")
+            self.assert_rewritten(responses, expected, f"{mode} IPv4 keep-alive")
+            if len(responses[0]["padding"]) != 65536:
+                raise AssertionError(f"{mode}: large response was truncated")
+
+            post = self.probe("10.241.2.2", method="POST", body=POST_BODY, path="/post")
+            self.assert_rewritten(post, expected, f"{mode} IPv4 POST")
+            if post[0]["body"] != POST_BODY:
+                raise AssertionError(f"{mode}: request body was modified")
+
+            no_ua = self.probe("10.241.2.2", user_agent=None, path="/no-user-agent")
+            if no_ua[0]["user_agent"] is not None:
+                raise AssertionError(f"{mode}: added an absent User-Agent")
+
+            bypass = self.probe("10.241.2.2", port=443, path="/bypass")
+            if bypass[0]["user_agent"] != TEST_USER_AGENT:
+                raise AssertionError(f"{mode}: unexpectedly modified bypass port 443")
+
+            if self.ipv6:
+                ipv6 = self.probe("fd42:241:2::2", requests=2, path="/ipv6")
+                self.assert_rewritten(ipv6, expected, f"{mode} IPv6")
+        finally:
+            self.stop_ua2f()
+            self.flush_firewall()
+
+    def read_ua2f_log(self):
+        self.ua2f_log.flush()
+        try:
+            return Path(self.ua2f_log.name).read_text(errors="replace")
+        except OSError:
+            return ""
+
+    def restore_coverage_ownership(self):
+        uid = os.environ.get("SUDO_UID")
+        gid = os.environ.get("SUDO_GID")
+        if uid is None or gid is None:
+            return
+        for coverage_file in self.binary.parent.rglob("*.gcda"):
+            os.chown(coverage_file, int(uid), int(gid))
+
+    def cleanup(self):
+        try:
+            self.stop_ua2f()
+        except RuntimeError as error:
+            print(error, file=sys.stderr)
+        if self.origin_process is not None and self.origin_process.poll() is None:
+            self.origin_process.terminate()
+            try:
+                self.origin_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.origin_process.kill()
+                self.origin_process.wait(timeout=5)
+        for namespace in (self.client_ns, self.router_ns, self.origin_ns):
+            self._run(["ip", "netns", "delete", namespace], check=False)
+        self.restore_coverage_ownership()
+        self.ua2f_log.close()
+
+    def run(self):
+        self.preflight()
+        try:
+            self.setup_network()
+            self.start_origin()
+            for mode in self.modes:
+                self.exercise_mode(mode)
+            print(f"[netns] passed modes: {', '.join(self.modes)}", flush=True)
+        except Exception:
+            print(self.read_ua2f_log(), file=sys.stderr)
+            raise
+        finally:
+            self.cleanup()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("binary")
+    parser.add_argument("--modes", default="NFQUEUE,REDIRECT,TPROXY")
+    parser.add_argument("--skip-ipv6", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    arguments = parse_args()
+    selected_modes = [mode.strip().upper() for mode in arguments.modes.split(",") if mode.strip()]
+    invalid_modes = set(selected_modes) - {"NFQUEUE", "REDIRECT", "TPROXY"}
+    if invalid_modes:
+        raise SystemExit(f"unsupported modes: {', '.join(sorted(invalid_modes))}")
+    RoutedIntegrationTest(arguments.binary, selected_modes, ipv6=not arguments.skip_ipv6).run()

--- a/scripts/test_openwrt_qemu.py
+++ b/scripts/test_openwrt_qemu.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Boot OpenWrt in QEMU and exercise UA2F as a real routed package."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+import pexpect
+
+
+TEST_USER_AGENT = "UA2F-OpenWrt-QEMU/1.0"
+GUEST_PROMPT = re.compile(r"root@[^:\r\n]+:[^#\r\n]*# ")
+
+
+class OpenWrtQemuTest:
+    def __init__(self, image, package, expected_version, log_path, boot_timeout):
+        self.image = Path(image).resolve()
+        self.package = Path(package).resolve()
+        self.expected_version = expected_version
+        self.log_path = Path(log_path).resolve()
+        self.boot_timeout = boot_timeout
+        self.helper = Path(__file__).with_name("http_test_endpoint.py").resolve()
+
+        suffix = f"{os.getpid():x}"[-5:]
+        self.client_ns = f"ua2f-qemu-client-{suffix}"
+        self.origin_ns = f"ua2f-qemu-origin-{suffix}"
+        self.lan_bridge = f"u2b{suffix}l"
+        self.wan_bridge = f"u2b{suffix}w"
+        self.lan_tap = f"u2t{suffix}l"
+        self.wan_tap = f"u2t{suffix}w"
+        self.client_if = f"u2c{suffix}"
+        self.client_host_if = f"u2h{suffix}l"
+        self.origin_if = f"u2o{suffix}"
+        self.origin_host_if = f"u2h{suffix}w"
+
+        self.work_dir = None
+        self.qemu = None
+        self.qemu_log = None
+        self.package_server = None
+        self.origin_server = None
+        self.package_server_port = None
+
+    @staticmethod
+    def _run(command, check=True, capture=False, timeout=60):
+        result = subprocess.run(
+            [str(part) for part in command],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stderr=subprocess.STDOUT if capture else subprocess.DEVNULL,
+            timeout=timeout,
+        )
+        if check and result.returncode != 0:
+            output = result.stdout.strip() if result.stdout else ""
+            raise RuntimeError(f"command failed ({result.returncode}): {' '.join(map(str, command))}\n{output}")
+        return result
+
+    def _ns_run(self, namespace, command, check=True, capture=False, timeout=60):
+        return self._run(
+            ["ip", "netns", "exec", namespace, *command],
+            check=check,
+            capture=capture,
+            timeout=timeout,
+        )
+
+    def preflight(self):
+        if os.name != "posix" or os.geteuid() != 0:
+            raise RuntimeError("test_openwrt_qemu.py requires Linux root privileges")
+        if not self.image.is_file():
+            raise RuntimeError(f"OpenWrt image not found: {self.image}")
+        if not self.package.is_file():
+            raise RuntimeError(f"UA2F package not found: {self.package}")
+        if not self.helper.is_file():
+            raise RuntimeError(f"HTTP test helper not found: {self.helper}")
+        for executable in ("ip", "qemu-img", "qemu-system-x86_64"):
+            if shutil.which(executable) is None:
+                raise RuntimeError(f"required executable not found: {executable}")
+
+    def setup_network(self):
+        for namespace in (self.client_ns, self.origin_ns):
+            self._run(["ip", "netns", "add", namespace])
+            self._run(["ip", "-n", namespace, "link", "set", "lo", "up"])
+
+        for bridge in (self.lan_bridge, self.wan_bridge):
+            self._run(["ip", "link", "add", bridge, "type", "bridge"])
+            self._run(["ip", "link", "set", bridge, "up"])
+
+        for tap, bridge in ((self.lan_tap, self.lan_bridge), (self.wan_tap, self.wan_bridge)):
+            self._run(["ip", "tuntap", "add", "dev", tap, "mode", "tap"])
+            self._run(["ip", "link", "set", tap, "master", bridge])
+            self._run(["ip", "link", "set", tap, "up"])
+
+        self._run(
+            ["ip", "link", "add", self.client_if, "type", "veth", "peer", "name", self.client_host_if]
+        )
+        self._run(["ip", "link", "set", self.client_if, "netns", self.client_ns])
+        self._run(["ip", "link", "set", self.client_host_if, "master", self.lan_bridge])
+        self._run(["ip", "link", "set", self.client_host_if, "up"])
+        self._run(["ip", "-n", self.client_ns, "addr", "add", "10.242.1.2/24", "dev", self.client_if])
+        self._run(["ip", "-n", self.client_ns, "link", "set", self.client_if, "up"])
+        self._run(["ip", "-n", self.client_ns, "route", "add", "default", "via", "10.242.1.1"])
+
+        self._run(
+            ["ip", "link", "add", self.origin_if, "type", "veth", "peer", "name", self.origin_host_if]
+        )
+        self._run(["ip", "link", "set", self.origin_if, "netns", self.origin_ns])
+        self._run(["ip", "link", "set", self.origin_host_if, "master", self.wan_bridge])
+        self._run(["ip", "link", "set", self.origin_host_if, "up"])
+        self._run(["ip", "-n", self.origin_ns, "addr", "add", "10.242.2.2/24", "dev", self.origin_if])
+        self._run(["ip", "-n", self.origin_ns, "link", "set", self.origin_if, "up"])
+        self._run(["ip", "-n", self.origin_ns, "route", "add", "default", "via", "10.242.2.1"])
+
+    @staticmethod
+    def _available_tcp_port():
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return sock.getsockname()[1]
+
+    def start_host_services(self):
+        self.package_server_port = self._available_tcp_port()
+        self.package_server = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "http.server",
+                str(self.package_server_port),
+                "--bind",
+                "0.0.0.0",
+                "--directory",
+                str(self.package.parent),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+        self.origin_server = subprocess.Popen(
+            [
+                "ip",
+                "netns",
+                "exec",
+                self.origin_ns,
+                sys.executable,
+                str(self.helper),
+                "serve",
+                "--port",
+                "80",
+                "--port",
+                "443",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+        time.sleep(0.5)
+        if self.package_server.poll() is not None:
+            raise RuntimeError("package HTTP server exited during startup")
+        if self.origin_server.poll() is not None:
+            raise RuntimeError("origin HTTP server exited during startup")
+
+    def start_qemu(self):
+        self.work_dir = tempfile.TemporaryDirectory(prefix="ua2f-openwrt-qemu-")
+        overlay = Path(self.work_dir.name) / "openwrt-overlay.qcow2"
+        self._run(
+            [
+                "qemu-img",
+                "create",
+                "-q",
+                "-f",
+                "qcow2",
+                "-F",
+                "raw",
+                "-b",
+                str(self.image),
+                str(overlay),
+            ]
+        )
+
+        acceleration = ["-accel", "tcg,thread=multi", "-cpu", "max"]
+        kvm = Path("/dev/kvm")
+        if kvm.exists() and os.access(kvm, os.R_OK | os.W_OK):
+            acceleration = ["-accel", "kvm", "-cpu", "host"]
+
+        command = [
+            "qemu-system-x86_64",
+            "-name",
+            "ua2f-openwrt-ci",
+            "-m",
+            "512",
+            "-smp",
+            "2",
+            "-no-reboot",
+            "-nographic",
+            "-monitor",
+            "none",
+            "-nic",
+            "none",
+            *acceleration,
+            "-drive",
+            f"file={overlay},format=qcow2,if=virtio",
+            "-netdev",
+            f"tap,id=lan,ifname={self.lan_tap},script=no,downscript=no",
+            "-device",
+            "virtio-net-pci,netdev=lan,mac=52:54:00:2a:01:01",
+            "-netdev",
+            f"tap,id=wan,ifname={self.wan_tap},script=no,downscript=no",
+            "-device",
+            "virtio-net-pci,netdev=wan,mac=52:54:00:2a:02:01",
+            "-netdev",
+            "user,id=mgmt",
+            "-device",
+            "virtio-net-pci,netdev=mgmt,mac=52:54:00:2a:03:01",
+        ]
+
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        self.qemu_log = self.log_path.open("w", encoding="utf-8", errors="replace")
+        self.qemu = pexpect.spawn(command[0], command[1:], encoding="utf-8", codec_errors="replace", timeout=30)
+        self.qemu.logfile = self.qemu_log
+        self._wait_for_shell()
+
+    def _wait_for_shell(self):
+        deadline = time.monotonic() + self.boot_timeout
+        while time.monotonic() < deadline:
+            timeout = max(1, min(30, int(deadline - time.monotonic())))
+            matched = self.qemu.expect(
+                [r"Please press Enter to activate this console", GUEST_PROMPT, pexpect.TIMEOUT, pexpect.EOF],
+                timeout=timeout,
+            )
+            if matched == 0:
+                self.qemu.sendline("")
+            elif matched == 1:
+                return
+            elif matched == 3:
+                raise RuntimeError("QEMU exited before the OpenWrt shell became ready")
+        raise RuntimeError(f"OpenWrt did not boot within {self.boot_timeout} seconds")
+
+    def guest_command(self, command, check=True, timeout=120):
+        marker = f"__UA2F_RC_{uuid.uuid4().hex}__"
+        self.qemu.sendline(f"{command}; ua2f_status=$?; echo {marker}$ua2f_status")
+        self.qemu.expect(re.escape(marker) + r"([0-9]+)", timeout=timeout)
+        output = self.qemu.before
+        status = int(self.qemu.match.group(1))
+        self.qemu.expect(GUEST_PROMPT, timeout=30)
+        if check and status != 0:
+            raise RuntimeError(f"guest command failed ({status}): {command}\n{output}")
+        return status, output
+
+    def configure_openwrt(self):
+        print("[qemu] configuring OpenWrt LAN, WAN, management, and firewall", flush=True)
+        self.guest_command("ubus wait_for network.interface", timeout=120)
+        self.guest_command("sleep 3")
+        commands = (
+            "uci -q delete network.lan || true",
+            "uci set network.lan=interface",
+            "uci set network.lan.device=eth0",
+            "uci set network.lan.proto=static",
+            "uci set network.lan.ipaddr=10.242.1.1",
+            "uci set network.lan.netmask=255.255.255.0",
+            "uci -q delete network.wan || true",
+            "uci set network.wan=interface",
+            "uci set network.wan.device=eth1",
+            "uci set network.wan.proto=static",
+            "uci set network.wan.ipaddr=10.242.2.1",
+            "uci set network.wan.netmask=255.255.255.0",
+            "uci -q delete network.wan6 || true",
+            "uci set network.mgmt=interface",
+            "uci set network.mgmt.device=eth2",
+            "uci set network.mgmt.proto=dhcp",
+            "uci commit network",
+            "/etc/init.d/network restart",
+            "sleep 8",
+            "uci set firewall.@zone[0].network=lan",
+            "uci set firewall.@zone[1].network='wan mgmt'",
+            "uci set firewall.@forwarding[0].src=lan",
+            "uci set firewall.@forwarding[0].dest=wan",
+            "uci commit firewall",
+            "/etc/init.d/firewall restart",
+            "sleep 3",
+        )
+        for command in commands:
+            self.guest_command(command)
+
+        self.guest_command("ip -4 addr show dev eth0")
+        self.guest_command("ip -4 addr show dev eth1")
+        self.guest_command("ip -4 addr show dev eth2")
+        self.guest_command("ping -c 1 -W 3 10.242.1.2")
+        self.guest_command("ping -c 1 -W 3 10.242.2.2")
+
+    def install_package(self):
+        print("[qemu] installing the freshly built UA2F IPK", flush=True)
+        package_url = (
+            f"http://10.0.2.2:{self.package_server_port}/"
+            f"{shlex.quote(self.package.name)}"
+        )
+        self.guest_command("opkg update", timeout=600)
+        self.guest_command(f"wget -O /tmp/ua2f.ipk {package_url}", timeout=120)
+        self.guest_command("opkg install /tmp/ua2f.ipk", timeout=600)
+        self.guest_command("opkg status ua2f | grep -q 'Status: install user installed'")
+        _, output = self.guest_command("/usr/bin/ua2f --version")
+        if self.expected_version not in output:
+            raise AssertionError(
+                f"installed UA2F version did not contain {self.expected_version!r}:\n{output}"
+            )
+
+    def probe(self, port=80, requests=1):
+        result = self._ns_run(
+            self.client_ns,
+            [
+                sys.executable,
+                str(self.helper),
+                "probe",
+                "--host",
+                "10.242.2.2",
+                "--port",
+                str(port),
+                "--requests",
+                str(requests),
+                "--path",
+                "/openwrt?padding=32768",
+                "--user-agent",
+                TEST_USER_AGENT,
+                "--timeout",
+                "15",
+            ],
+            capture=True,
+            timeout=60,
+        )
+        return json.loads(result.stdout)
+
+    @staticmethod
+    def assert_user_agent(responses, expected, label):
+        for index, response in enumerate(responses):
+            if response["user_agent"] != expected:
+                raise AssertionError(
+                    f"{label} response {index}: expected {expected!r}, got {response['user_agent']!r}"
+                )
+            if len(response["padding"]) != 32768:
+                raise AssertionError(f"{label} response {index}: response body was truncated")
+
+    def exercise_mode(self, mode):
+        print(f"[qemu] testing OpenWrt init/firewall mode {mode}", flush=True)
+        configure = (
+            "uci set ua2f.enabled.enabled=1 && "
+            "uci set ua2f.firewall.handle_fw=1 && "
+            "uci set ua2f.firewall.handle_tls=0 && "
+            "uci set ua2f.firewall.handle_intranet=1 && "
+            f"uci set ua2f.main.mode={mode} && "
+            "uci set ua2f.main.nfqueue_workers=2 && "
+            "uci set ua2f.main.proxy_workers=2 && "
+            "uci commit ua2f"
+        )
+        self.guest_command(configure)
+        self.guest_command("/etc/init.d/ua2f restart", timeout=60)
+        self.guest_command("sleep 2")
+        self.guest_command("/etc/init.d/ua2f running")
+        self.guest_command("nft list table inet ua2f")
+
+        # A second restart catches duplicate nft chains and stale TPROXY policy routes.
+        self.guest_command("/etc/init.d/ua2f restart", timeout=60)
+        self.guest_command("sleep 2")
+        self.guest_command("/etc/init.d/ua2f running")
+
+        rewritten = self.probe(requests=3)
+        self.assert_user_agent(rewritten, "F" * len(TEST_USER_AGENT), f"{mode} port 80")
+        bypassed = self.probe(port=443)
+        self.assert_user_agent(bypassed, TEST_USER_AGENT, f"{mode} port 443 bypass")
+
+    def stop_and_verify_cleanup(self):
+        self.guest_command("/etc/init.d/ua2f stop")
+        self.guest_command("sleep 1")
+        status, _ = self.guest_command("nft list table inet ua2f >/dev/null 2>&1", check=False)
+        if status == 0:
+            raise AssertionError("UA2F nft table remained after stopping the service")
+
+    @staticmethod
+    def _terminate_process(process):
+        if process is None or process.poll() is not None:
+            return
+        process.send_signal(signal.SIGTERM)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+    def cleanup(self):
+        if self.qemu is not None:
+            if self.qemu.isalive():
+                self.qemu.close(force=True)
+            self.qemu = None
+        if self.qemu_log is not None:
+            self.qemu_log.close()
+            self.qemu_log = None
+        self._terminate_process(self.origin_server)
+        self._terminate_process(self.package_server)
+        for namespace in (self.client_ns, self.origin_ns):
+            self._run(["ip", "netns", "delete", namespace], check=False)
+        for interface in (self.lan_tap, self.wan_tap, self.lan_bridge, self.wan_bridge):
+            self._run(["ip", "link", "delete", interface], check=False)
+        if self.work_dir is not None:
+            self.work_dir.cleanup()
+            self.work_dir = None
+
+    def run(self):
+        self.preflight()
+        try:
+            self.setup_network()
+            self.start_host_services()
+            self.start_qemu()
+            self.configure_openwrt()
+            self.install_package()
+            for mode in ("NFQUEUE", "REDIRECT", "TPROXY"):
+                self.exercise_mode(mode)
+            self.stop_and_verify_cleanup()
+            print("[qemu] all OpenWrt package and routing tests passed", flush=True)
+        finally:
+            self.cleanup()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True, help="decompressed OpenWrt x86_64 combined image")
+    parser.add_argument("--package", required=True, help="UA2F x86_64 .ipk built for the image release")
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--log", default="openwrt-qemu.log")
+    parser.add_argument("--boot-timeout", type=int, default=300)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    arguments = parse_args()
+    OpenWrtQemuTest(
+        arguments.image,
+        arguments.package,
+        arguments.expected_version,
+        arguments.log,
+        arguments.boot_timeout,
+    ).run()

--- a/scripts/test_openwrt_qemu.py
+++ b/scripts/test_openwrt_qemu.py
@@ -81,6 +81,8 @@ class OpenWrtQemuTest:
             raise RuntimeError(f"OpenWrt image not found: {self.image}")
         if not self.package.is_file():
             raise RuntimeError(f"UA2F package not found: {self.package}")
+        if self.package.suffix not in (".ipk", ".apk"):
+            raise RuntimeError(f"unsupported OpenWrt package format: {self.package.suffix}")
         if not self.helper.is_file():
             raise RuntimeError(f"HTTP test helper not found: {self.helper}")
         for executable in ("ip", "qemu-img", "qemu-system-x86_64"):
@@ -295,15 +297,22 @@ class OpenWrtQemuTest:
         self.guest_command("ping -c 1 -W 3 10.242.2.2")
 
     def install_package(self):
-        print("[qemu] installing the freshly built UA2F IPK", flush=True)
+        print(f"[qemu] installing the freshly built UA2F {self.package.suffix}", flush=True)
         package_url = (
             f"http://10.0.2.2:{self.package_server_port}/"
             f"{shlex.quote(self.package.name)}"
         )
-        self.guest_command("opkg update", timeout=600)
-        self.guest_command(f"wget -O /tmp/ua2f.ipk {package_url}", timeout=120)
-        self.guest_command("opkg install /tmp/ua2f.ipk", timeout=600)
-        self.guest_command("opkg status ua2f | grep -q 'Status: install user installed'")
+        remote_package = f"/tmp/ua2f{self.package.suffix}"
+        if self.package.suffix == ".apk":
+            self.guest_command("apk update", timeout=600)
+            self.guest_command(f"wget -O {remote_package} {package_url}", timeout=120)
+            self.guest_command(f"apk add --allow-untrusted {remote_package}", timeout=600)
+            self.guest_command("apk info -e ua2f")
+        else:
+            self.guest_command("opkg update", timeout=600)
+            self.guest_command(f"wget -O {remote_package} {package_url}", timeout=120)
+            self.guest_command(f"opkg install {remote_package}", timeout=600)
+            self.guest_command("opkg status ua2f | grep -q 'Status: install user installed'")
         _, output = self.guest_command("/usr/bin/ua2f --version")
         if self.expected_version not in output:
             raise AssertionError(
@@ -428,7 +437,7 @@ class OpenWrtQemuTest:
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", required=True, help="decompressed OpenWrt x86_64 combined image")
-    parser.add_argument("--package", required=True, help="UA2F x86_64 .ipk built for the image release")
+    parser.add_argument("--package", required=True, help="UA2F x86_64 .ipk or .apk built for the image release")
     parser.add_argument("--expected-version", required=True)
     parser.add_argument("--log", default="openwrt-qemu.log")
     parser.add_argument("--boot-timeout", type=int, default=300)

--- a/src/config.c
+++ b/src/config.c
@@ -21,6 +21,21 @@ struct ua2f_config config = {
     .proxy_workers = 0,
 };
 
+static void reset_config(void) {
+    free(config.custom_ua);
+    config = (struct ua2f_config){
+        .use_custom_ua = false,
+        .custom_ua = NULL,
+        .disable_connmark = false,
+        .max_http_sessions = 0,
+        .session_ttl = 300,
+        .mode = UA2F_MODE_NFQUEUE,
+        .listen_port = UA2F_DEFAULT_PROXY_PORT,
+        .nfqueue_workers = 1,
+        .proxy_workers = 0,
+    };
+}
+
 static void load_int_option(struct uci_context *ctx, struct uci_section *section, const char *name, int min_value,
                             int max_value, int *target) {
     const __auto_type value = uci_lookup_option_string(ctx, section, name);
@@ -38,17 +53,27 @@ static void load_int_option(struct uci_context *ctx, struct uci_section *section
     syslog(LOG_WARNING, "Invalid %s value: %s, using default %d", name, value, *target);
 }
 
-void load_config() {
+bool load_config_from_dir(const char *config_dir) {
+    reset_config();
+
     const __auto_type ctx = uci_alloc_context();
     if (ctx == NULL) {
         syslog(LOG_ERR, "Failed to allocate uci context");
-        return;
+        return false;
     }
 
+    if (config_dir != NULL && uci_set_confdir(ctx, config_dir) != UCI_OK) {
+        syslog(LOG_ERR, "Failed to use UCI config directory: %s", config_dir);
+        uci_free_context(ctx);
+        return false;
+    }
+
+    bool loaded = false;
     struct uci_package *package;
     if (uci_load(ctx, "ua2f", &package) != UCI_OK) {
         goto cleanup;
     }
+    loaded = true;
 
     // find ua2f.main.custom_ua
     const __auto_type section = uci_lookup_section(ctx, package, "main");
@@ -58,8 +83,8 @@ void load_config() {
 
     const __auto_type custom_ua = uci_lookup_option_string(ctx, section, "custom_ua");
     if (custom_ua != NULL && strlen(custom_ua) > 0) {
-        config.use_custom_ua = true;
         config.custom_ua = strdup(custom_ua);
+        config.use_custom_ua = config.custom_ua != NULL;
     }
 
     const __auto_type disable_connmark = uci_lookup_option_string(ctx, section, "disable_connmark");
@@ -97,6 +122,15 @@ void load_config() {
 
 cleanup:
     uci_free_context(ctx);
+    return loaded;
+}
+
+void load_config(void) {
+    (void)load_config_from_dir(NULL);
+}
+
+void free_config(void) {
+    reset_config();
 }
 #undef UA2F_MAX_CONFIG_WORKERS
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -21,7 +21,9 @@ struct ua2f_config {
     int proxy_workers; // 0 = auto, otherwise 1-16
 };
 
-void load_config();
+void load_config(void);
+bool load_config_from_dir(const char *config_dir);
+void free_config(void);
 
 extern struct ua2f_config config;
 

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+extern "C" {
+#include <config.h>
+}
+
+class ConfigTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        char path[] = "/tmp/ua2f-config-test-XXXXXX";
+        const char *created = mkdtemp(path);
+        ASSERT_NE(created, nullptr);
+        config_dir = created;
+        config_path = config_dir + "/ua2f";
+        free_config();
+    }
+
+    void TearDown() override {
+        free_config();
+        unlink(config_path.c_str());
+        rmdir(config_dir.c_str());
+    }
+
+    void WriteConfig(const std::string &contents) const {
+        std::ofstream output(config_path);
+        ASSERT_TRUE(output.is_open());
+        output << contents;
+        output.close();
+        ASSERT_TRUE(output.good());
+    }
+
+    std::string config_dir;
+    std::string config_path;
+};
+
+TEST_F(ConfigTest, LoadsEverySupportedMainOption) {
+    WriteConfig(R"(
+config ua2f 'main'
+    option custom_ua 'Test UA/1.0'
+    option disable_connmark '1'
+    option max_http_sessions '42'
+    option session_ttl '15'
+    option mode 'TPROXY'
+    option listen_port '12345'
+    option nfqueue_workers '4'
+    option proxy_workers '3'
+)");
+
+    ASSERT_TRUE(load_config_from_dir(config_dir.c_str()));
+    EXPECT_TRUE(config.use_custom_ua);
+    ASSERT_NE(config.custom_ua, nullptr);
+    EXPECT_STREQ(config.custom_ua, "Test UA/1.0");
+    EXPECT_TRUE(config.disable_connmark);
+    EXPECT_EQ(config.max_http_sessions, 42);
+    EXPECT_EQ(config.session_ttl, 15);
+    EXPECT_EQ(config.mode, UA2F_MODE_TPROXY);
+    EXPECT_EQ(config.listen_port, 12345);
+    EXPECT_EQ(config.nfqueue_workers, 4);
+    EXPECT_EQ(config.proxy_workers, 3);
+}
+
+TEST_F(ConfigTest, InvalidValuesKeepDefaults) {
+    WriteConfig(R"(
+config ua2f 'main'
+    option max_http_sessions '-1'
+    option session_ttl '0'
+    option mode 'invalid'
+    option listen_port '70000'
+    option nfqueue_workers '17'
+    option proxy_workers '-1'
+)");
+
+    ASSERT_TRUE(load_config_from_dir(config_dir.c_str()));
+    EXPECT_FALSE(config.use_custom_ua);
+    EXPECT_EQ(config.custom_ua, nullptr);
+    EXPECT_FALSE(config.disable_connmark);
+    EXPECT_EQ(config.max_http_sessions, 0);
+    EXPECT_EQ(config.session_ttl, 300);
+    EXPECT_EQ(config.mode, UA2F_MODE_NFQUEUE);
+    EXPECT_EQ(config.listen_port, UA2F_DEFAULT_PROXY_PORT);
+    EXPECT_EQ(config.nfqueue_workers, 1);
+    EXPECT_EQ(config.proxy_workers, 0);
+}
+
+TEST_F(ConfigTest, MissingPackageRestoresDefaults) {
+    config.use_custom_ua = true;
+    config.custom_ua = strdup("stale");
+    config.mode = UA2F_MODE_REDIRECT;
+
+    EXPECT_FALSE(load_config_from_dir(config_dir.c_str()));
+    EXPECT_FALSE(config.use_custom_ua);
+    EXPECT_EQ(config.custom_ua, nullptr);
+    EXPECT_EQ(config.mode, UA2F_MODE_NFQUEUE);
+    EXPECT_EQ(config.listen_port, UA2F_DEFAULT_PROXY_PORT);
+}
+
+TEST_F(ConfigTest, ReloadClearsOptionsRemovedFromTheFile) {
+    WriteConfig(R"(
+config ua2f 'main'
+    option custom_ua 'first'
+    option mode 'REDIRECT'
+)");
+    ASSERT_TRUE(load_config_from_dir(config_dir.c_str()));
+    ASSERT_TRUE(config.use_custom_ua);
+    ASSERT_EQ(config.mode, UA2F_MODE_REDIRECT);
+
+    WriteConfig(R"(
+config ua2f 'main'
+    option session_ttl '60'
+)");
+    ASSERT_TRUE(load_config_from_dir(config_dir.c_str()));
+    EXPECT_FALSE(config.use_custom_ua);
+    EXPECT_EQ(config.custom_ua, nullptr);
+    EXPECT_EQ(config.mode, UA2F_MODE_NFQUEUE);
+    EXPECT_EQ(config.session_ttl, 60);
+}


### PR DESCRIPTION
## Summary

- improve UCI and routed-mode test coverage
- add QEMU tests for installed OpenWrt packages and real forwarded traffic
- support OpenWrt 24.10.8 and 25.12.5, including IPK and APK artifacts
- fix OpenWrt package metadata and TPROXY rules

## Validation

- NFQUEUE, REDIRECT, and TPROXY passed on official 24.10.8 and 25.12.5 x86_64 images
- OpenWrt 25.12.5 SDK built and installed the UA2F APK successfully
